### PR TITLE
Converted increment_id to a varchar/text field.

### DIFF
--- a/app/code/community/ProxiBlue/OrderSyncQueRunner/Block/Adminhtml/Que/Grid.php
+++ b/app/code/community/ProxiBlue/OrderSyncQueRunner/Block/Adminhtml/Que/Grid.php
@@ -39,7 +39,7 @@ class ProxiBlue_OrderSyncQueRunner_Block_Adminhtml_Que_Grid
             "header" => Mage::helper("ordersyncquerunner")->__("Order ID"),
             "align" => "right",
             "width" => "50px",
-            "type" => "number",
+            "type" => "text",
             "index" => "increment_id",
         ));
 

--- a/app/code/community/ProxiBlue/OrderSyncQueRunner/sql/ordersyncquerunner_setup/install-0.0.1.php
+++ b/app/code/community/ProxiBlue/OrderSyncQueRunner/sql/ordersyncquerunner_setup/install-0.0.1.php
@@ -11,8 +11,7 @@ $table = $installer->getConnection()
         'nullable'  => false,
         'primary'   => true,
         ), 'Id')
-    ->addColumn('increment_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
-        'unsigned'  => true,
+    ->addColumn('increment_id', Varien_Db_Ddl_Table::TYPE_TEXT, 50, array(
         'nullable'  => true,
         ), 'Order Increment Id')
     ->addColumn('entity_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(


### PR DESCRIPTION
Order increment IDs are actually a varchar field in Magento, and can contain non-numeric characters. This patch increases compatibility.
